### PR TITLE
Update dependencies for gem to be compatible with `omniauth v2.0`

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -5,7 +5,7 @@
 
 guard 'minitest' do
   # with Minitest::Unit
-  watch(%r{^test/(.*)\/(.*)_test\.rb})
+  watch(%r{^test/(.*)/(.*)_test\.rb})
   watch(%r{^lib/(.*)\.rb}) { |m| "test/lib/#{m[1]}_test.rb" }
   watch(%r{^test/test_helper\.rb}) { 'test' }
 end

--- a/lib/omniauth/openid_connect/errors.rb
+++ b/lib/omniauth/openid_connect/errors.rb
@@ -3,7 +3,9 @@
 module OmniAuth
   module OpenIDConnect
     class Error < RuntimeError; end
+
     class MissingCodeError < Error; end
+
     class MissingIdTokenError < Error; end
   end
 end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -256,6 +256,12 @@ module OmniAuth
         session.delete('omniauth.nonce')
       end
 
+      def script_name
+        return '' if @env.nil?
+
+        super
+      end
+
       def session
         return {} if @env.nil?
 

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -19,17 +19,17 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'addressable', '~> 2.5'
+  spec.add_dependency 'addressable', '~> 2.8'
   spec.add_dependency 'omniauth', '~> 1.9'
-  spec.add_dependency 'openid_connect', '~> 1.1'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
-  spec.add_development_dependency 'faker', '~> 1.6'
-  spec.add_development_dependency 'guard', '~> 2.14'
-  spec.add_development_dependency 'guard-bundler', '~> 2.2'
+  spec.add_dependency 'openid_connect', '~> 1.2'
+  spec.add_development_dependency 'coveralls_reborn', '~> 0.22'
+  spec.add_development_dependency 'faker', '~> 2.19'
+  spec.add_development_dependency 'guard', '~> 2.17'
+  spec.add_development_dependency 'guard-bundler', '~> 3.0'
   spec.add_development_dependency 'guard-minitest', '~> 2.4'
-  spec.add_development_dependency 'minitest', '~> 5.1'
-  spec.add_development_dependency 'mocha', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.63'
-  spec.add_development_dependency 'simplecov', '~> 0.12'
+  spec.add_development_dependency 'minitest', '~> 5.14'
+  spec.add_development_dependency 'mocha', '~> 1.13'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rubocop', '~> 1.19'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
 end

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'addressable', '~> 2.8'
-  spec.add_dependency 'omniauth', '~> 1.9'
+  spec.add_dependency 'omniauth', '~> 2.0'
   spec.add_dependency 'openid_connect', '~> 1.2'
   spec.add_development_dependency 'coveralls_reborn', '~> 0.22'
   spec.add_development_dependency 'faker', '~> 2.19'

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -35,7 +35,7 @@ module OmniAuth
         config.stubs(:end_session_endpoint).returns('https://example.com/logout')
         ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
 
-        request.stubs(:path_info).returns('/auth/openid_connect/logout')
+        request.stubs(:path).returns('/auth/openid_connect/logout')
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.other_phase
@@ -59,7 +59,7 @@ module OmniAuth
         config.stubs(:end_session_endpoint).returns('https://example.com/logout')
         ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
 
-        request.stubs(:path_info).returns('/auth/openid_connect/logout')
+        request.stubs(:path).returns('/auth/openid_connect/logout')
 
         strategy.expects(:redirect).with(expected_redirect)
         strategy.other_phase
@@ -69,7 +69,7 @@ module OmniAuth
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
 
-        request.stubs(:path_info).returns('/auth/openid_connect/logout')
+        request.stubs(:path).returns('/auth/openid_connect/logout')
 
         strategy.expects(:call_app!)
         strategy.other_phase
@@ -165,7 +165,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
         strategy.options.client_signing_alg = :RS256
@@ -197,7 +197,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('id_token' => code, 'state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
         strategy.options.client_signing_alg = :RS256
@@ -229,7 +229,7 @@ module OmniAuth
         jwks = JSON::JWK::Set.new(JSON.parse(File.read('test/fixtures/jwks.json'))['keys'])
 
         request.stubs(:params).returns('code' => code, 'state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
@@ -270,7 +270,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('error' => 'invalid_request')
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
         strategy.expects(:fail!)
@@ -282,7 +282,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => 'foobar')
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
         strategy.expects(:fail!)
@@ -293,7 +293,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
 
@@ -305,7 +305,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
         strategy.options.response_type = 'id_token'
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
@@ -318,7 +318,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
         strategy.options.response_type = :id_token
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
@@ -332,7 +332,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
 
@@ -352,7 +352,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
 
@@ -372,7 +372,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
 
@@ -392,7 +392,7 @@ module OmniAuth
         state = SecureRandom.hex(16)
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
 
@@ -493,7 +493,7 @@ module OmniAuth
         # the following should fail because the wrong state is passed to the callback
         code = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => 43)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.call!('rack.session' => session)
         strategy.expects(:fail!)
@@ -502,7 +502,7 @@ module OmniAuth
 
       def test_dynamic_state
         # Stub request parameters
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
         strategy.call!('rack.session' => { }, QUERY_STRING: { state: 'abc', client_id: '123' } )
 
         strategy.options.state = lambda { |env|
@@ -535,7 +535,7 @@ module OmniAuth
         }.to_json
         success = Struct.new(:status, :body).new(200, json_response)
 
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
 
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
@@ -600,7 +600,7 @@ module OmniAuth
         )
 
         request.stubs(:params).returns('state' => state, 'nounce' => nonce, 'id_token' => id_token)
-        request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.stubs(:decode_id_token).returns(id_token)
         strategy.stubs(:stored_state).returns(state)


### PR DESCRIPTION
As the `omniauth` is now at version > 2.0, I have updated `omniauth_openid_connect` so that it is compatible with the latest version. I also updated the other dependencies so that they use the latest versions as well.

There were two major changes I found that needed to be fixed:

1. In `omniauth` the following methods `request_path` was updated to include `script_name`, The method for `script_name` is:
```
def script_name
  @env['SCRIPT_NAME'] || ''
end
```
and it would raise an error whenever `request_path` was called as `@env` would be nil. Therefore, I added a method into `lib/omniauth/strategies/openid_connect.rb` which will return `''` if `@env` is `nil` and will use the method in `lib/omniauth/strategy.rb` as normal if `@env` is not `nil`. This is similar to what was done for `session` already.

2. There was a change in the `omniauth` gem for the `current_path` in `lib/omniauth/strategy.rb` which changed from using `path_info` to the `path` method as `path_info` has been depreciated. This did not affect the code in the library but it did impact on the tests. This is because `path_info` was being stubbed. Therefore, I changed the places in the tests where `path_info` was being stubbed to stub `path` instead.

After these changes were made, I was able to run all the test successfully.
